### PR TITLE
Refresh package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,15 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "spring-launcher",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@electron/remote": "^2.0.1",
         "7zip-bin": "^5.0.3",
         "aws-sdk": "^2.1044.0",
-        "electron-is-dev": "^1.2.0",
         "chokidar": "^3.5.2",
+        "electron-is-dev": "^1.2.0",
         "electron-log": "^4.4.4",
         "electron-settings": "^3.2.0",
         "electron-updater": "^4.6.1",
@@ -629,8 +630,6 @@
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
         "fs-extra": "^8.1.0",
-        "global-agent": "^2.0.2",
-        "global-tunnel-ng": "^2.7.1",
         "got": "^9.6.0",
         "progress": "^2.0.3",
         "semver": "^6.2.0",
@@ -1057,7 +1056,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -2265,7 +2263,6 @@
       "integrity": "sha512-vyxPxP5arcAqN4F/ebHd/HhwnAiZtwhglvdmc7BR2f0ywbVNTOpSeyhLDbGXtE/y58hv1oC75TaNIXutnsOZsQ==",
       "dev": true,
       "dependencies": {
-        "@types/glob": "^7.1.1",
         "chromium-pickle-js": "^0.2.0",
         "commander": "^5.0.0",
         "glob": "^7.1.6",
@@ -3006,7 +3003,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -3963,6 +3959,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/electron-is-dev": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.2.0.tgz",
+      "integrity": "sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw=="
     },
     "node_modules/electron-log": {
       "version": "4.4.4",
@@ -4923,7 +4924,6 @@
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dependencies": {
-        "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
@@ -6414,7 +6414,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -14120,6 +14119,11 @@
           "dev": true
         }
       }
+    },
+    "electron-is-dev": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.2.0.tgz",
+      "integrity": "sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw=="
     },
     "electron-log": {
       "version": "4.4.4",


### PR DESCRIPTION
Looks like `npm install` wasn't run for some time here, and it got a bit out of sync. This is blocking me from fixing the flatpak package that currently has launcher (not chobby, chobby is up to date) version from January.