### PR TITLE
Add Discord Rich Presence support - Launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ data
 
 # spring-launcher temporary files
 Settings
+src/config.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@electron/remote": "2.0.10",
         "7zip-bin": "5.1.1",
         "chokidar": "3.5.3",
+        "discord-rpc": "^4.0.1",
         "electron-log": "5.0.1",
         "electron-settings": "4.0.2",
         "electron-updater": "6.1.7",
@@ -1386,6 +1387,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -1945,6 +1955,18 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/discord-rpc": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/discord-rpc/-/discord-rpc-4.0.1.tgz",
+      "integrity": "sha512-HOvHpbq5STRZJjQIBzwoKnQ0jHplbEWFWlPDwXXKm/bILh4nzjcg7mNqll0UY7RsjFoaXA7e/oYb/4lvpda2zA==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "ws": "^7.3.1"
+      },
+      "optionalDependencies": {
+        "register-scheme": "github:devsnek/node-register-scheme"
       }
     },
     "node_modules/dmg-builder": {
@@ -2610,6 +2632,12 @@
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -3762,7 +3790,6 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
       "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
-      "dev": true,
       "optional": true
     },
     "node_modules/node-downloader-helper": {
@@ -4200,6 +4227,17 @@
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
+    "node_modules/register-scheme": {
+      "version": "0.0.2",
+      "resolved": "git+ssh://git@github.com/devsnek/node-register-scheme.git#e7cc9a63a1f512565da44cb57316d9fb10750e17",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.3.0",
+        "node-addon-api": "^1.3.0"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -4967,6 +5005,26 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xhr": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@electron/remote": "2.0.10",
     "7zip-bin": "5.1.1",
     "chokidar": "3.5.3",
+    "discord-rpc": "^4.0.1",
     "electron-log": "5.0.1",
     "electron-settings": "4.0.2",
     "electron-updater": "6.1.7",

--- a/src/exts/discord_integration.js
+++ b/src/exts/discord_integration.js
@@ -1,11 +1,11 @@
 const { bridge } = require('../spring_api');
 const { log } = require('../spring_log');
 const { config } = require('../launcher_config');
-const DiscordRPC = require("discord-rpc");
+const DiscordRPC = require('discord-rpc');
 
 if (!config.discord_rich_presence?.application_id) {
-    log.warn("config.discord_rich_presence.application_id not defined, integration disabled");
-    return
+	log.warn('config.discord_rich_presence.application_id not defined, integration disabled');
+	return;
 }
 
 // Application ID from https://discord.com/developers/applications/<applicationId>/
@@ -15,68 +15,68 @@ let rpc = null;
 DiscordRPC.register(applicationId);
 
 async function TryToLogin() {
-    if (rpc) return;
-    try {
-        rpc = new DiscordRPC.Client({ transport: 'ipc' });
-        rpc.on('disconnected', () => {
-            rpc = null;
-        });
-        await rpc.login({ clientId: applicationId });
-    } catch (error) {
-        rpc = null;
-        log.warn("Discord RPC login error - Discord not running?");
-    }
+	if (rpc) return;
+	try {
+		rpc = new DiscordRPC.Client({ transport: 'ipc' });
+		rpc.on('disconnected', () => {
+			rpc = null;
+		});
+		await rpc.login({ clientId: applicationId });
+	} catch (error) {
+		rpc = null;
+		log.warn('Discord RPC login error - Discord not running?');
+	}
 }
 
 bridge.on('DiscordSetActivity', async command => {
-    // command
-    // https://discord.com/developers/docs/rich-presence/how-to#updating-presence-update-presence-payload-fields
-    // {
-    //     state : string - Playing, spectating, in menu, in lobby, watching replay...
-    //     details : string - Map name
-    //     startTimestamp : unix timestamp - including will show time as "elapsed"
-    //     playerCount : int > 0
-    //     maxPlayerCount : int > 0
-    //     partyId : string - battle ID for now
-    //     largeImageText : string - tooltip for the largeImageKey
-    //     smallImageKey : string - name of the uploaded image for the large profile artwork, can also be URL
-    //     smallImageText : string - tooltip for the smallImageKey
-    // }
-    if (!rpc) await TryToLogin()
-    if (!rpc) return
+	// command
+	// https://discord.com/developers/docs/rich-presence/how-to#updating-presence-update-presence-payload-fields
+	// {
+	//     state : string - Playing, spectating, in menu, in lobby, watching replay...
+	//     details : string - Map name
+	//     startTimestamp : unix timestamp - including will show time as "elapsed"
+	//     playerCount : int > 0
+	//     maxPlayerCount : int > 0
+	//     partyId : string - battle ID for now
+	//     largeImageText : string - tooltip for the largeImageKey
+	//     smallImageKey : string - name of the uploaded image for the large profile artwork, can also be URL
+	//     smallImageText : string - tooltip for the smallImageKey
+	// }
+	if (!rpc) await TryToLogin();
+	if (!rpc) return;
 
-    let activity = {
-        state: command.state,
-        details: command.mapName,
-        startTimestamp: command.startTimestamp,
-        largeImageText: command.largeImageText ?? config.discord_rich_presence.large_image_text_default,
-        smallImageKey: command.smallImageKey ?? config.discord_rich_presence.small_image_key_default,    
-        smallImageText: command.smallImageText ?? config.discord_rich_presence.small_image_text_default,
-        buttons: [{
-            label: config.discord_rich_presence.button_label,
-            url: config.discord_rich_presence.button_url
-        }]
-    };
+	let activity = {
+		state: command.state,
+		details: command.mapName,
+		startTimestamp: command.startTimestamp,
+		largeImageText: command.largeImageText ?? config.discord_rich_presence.large_image_text_default,
+		smallImageKey: command.smallImageKey ?? config.discord_rich_presence.small_image_key_default,    
+		smallImageText: command.smallImageText ?? config.discord_rich_presence.small_image_text_default,
+		buttons: [{
+			label: config.discord_rich_presence.button_label,
+			url: config.discord_rich_presence.button_url
+		}]
+	};
 
-    if (command.mapName && config.discord_rich_presence.minimap_url) {
-        activity.largeImageKey = config.discord_rich_presence.minimap_url.replace("<map>", encodeURIComponent(command.mapName));
-    } else {
-        activity.largeImageKey = config.discord_rich_presence.large_image_key_default;
-    }
+	if (command.mapName && config.discord_rich_presence.minimap_url) {
+		activity.largeImageKey = config.discord_rich_presence.minimap_url.replace('<map>', encodeURIComponent(command.mapName));
+	} else {
+		activity.largeImageKey = config.discord_rich_presence.large_image_key_default;
+	}
 
-    // Both playerCount and maxPlayerCount have to be > 0 to avoid errors
-    if (command.playerCount > 0 && command.maxPlayerCount > 0) {
-        activity.partySize = command.playerCount;
-        activity.partyMax = command.maxPlayerCount;
-    }
+	// Both playerCount and maxPlayerCount have to be > 0 to avoid errors
+	if (command.playerCount > 0 && command.maxPlayerCount > 0) {
+		activity.partySize = command.playerCount;
+		activity.partyMax = command.maxPlayerCount;
+	}
 
-    if (command.partyId) {
-        activity.partyId = command.battleId.toString();
-    }
+	if (command.partyId) {
+		activity.partyId = command.battleId.toString();
+	}
 
-    try {
-        await rpc.setActivity(activity);
-    } catch (error) {
-        log.warn("Error while setting activity:", error)
-    }
+	try {
+		await rpc.setActivity(activity);
+	} catch (error) {
+		log.warn('Error while setting activity:', error);
+	}
 });

--- a/src/exts/discord_integration.js
+++ b/src/exts/discord_integration.js
@@ -58,9 +58,9 @@ bridge.on('DiscordSetActivity', async command => {
     };
 
     if (command.details && config.discord_rich_presence.minimap_url) {
-        activity.largeImageKey = config.discord_rich_presence.minimap_url.replace("<map>", encodeURIComponent(command.details))
+        activity.largeImageKey = config.discord_rich_presence.minimap_url.replace("<map>", encodeURIComponent(command.details));
     } else {
-        activity.largeImageKey = config.discord_rich_presence.large_image_key_default
+        activity.largeImageKey = config.discord_rich_presence.large_image_key_default;
     }
 
     // Both playerCount and maxPlayerCount have to be > 0 to avoid errors

--- a/src/exts/discord_integration.js
+++ b/src/exts/discord_integration.js
@@ -3,8 +3,8 @@ const { log } = require('../spring_log');
 const { config } = require('../launcher_config');
 const DiscordRPC = require("discord-rpc");
 
-if (config.discord_rich_presence.application_id == null) {
-    log.warn("config.discord_rich_presence.application_id not defined");
+if (!config.discord_rich_presence?.application_id) {
+    log.warn("config.discord_rich_presence.application_id not defined, integration disabled");
     return
 }
 

--- a/src/exts/discord_integration.js
+++ b/src/exts/discord_integration.js
@@ -1,0 +1,71 @@
+const { bridge } = require('../spring_api');
+const { log } = require('../spring_log');
+const DiscordRPC = require("discord-rpc");
+
+// Application ID from https://discord.com/developers/applications/<clientId>/
+const clientId = '1185990483143569448';
+
+DiscordRPC.register(clientId);
+const rpc = new DiscordRPC.Client({ transport: 'ipc' });
+
+bridge.on('DiscordSetActivity', async command => {
+    if (!rpc) {
+        log.warn("DiscordSetActivity - No Discord RPC");
+        return
+    };
+
+    // Playing, spectating, in menu, in lobby, watching replay...
+    const state = command.state;
+
+    // Map name
+    const details = command.details;
+
+    // Epoch seconds for game start - including will show time as "elapsed"
+    const startTimestamp = command.startTimestamp;
+
+    // Name of the uploaded image for the large profile artwork
+    // Minimap Image URL
+    const largeImageKey = command.details ?
+        `https://maps-metadata.beyondallreason.dev/latest/discordPresenceThumb/redir.${encodeURIComponent(command.details)}.1024.jpg` :
+        'barlogobox';
+
+    // Tooltip for the largeImageKey
+    const largeImageText = command.largeImageText ? command.largeImageText : 'Beyond All Reason';
+
+    // Name of the uploaded image key for the small profile artwork
+    const smallImageKey = command.smallImageKey ? command.smallImageKey : 'barlogobox';
+
+    // Tooltip for the smallImageKey
+    const smallImageText = command.smallImageKey ? command.smallImageKey : 'Beyond All Reason';
+
+    // Both playerCount and maxPlayerCount have to be > 0 to avoid errors
+    let playerCount;
+    let maxPlayerCount;
+
+    if(command.playerCount > 0 && command.maxPlayerCount > 0) {
+        playerCount = command.playerCount;
+        maxPlayerCount = command.maxPlayerCount;
+    }
+
+    // Party id (battle id for now)
+    const partyId = String(command.partyId)
+
+    rpc.setActivity({
+        state: state,
+        details: details,
+        startTimestamp: startTimestamp,
+        largeImageKey: largeImageKey,
+        largeImageText: largeImageText,
+        smallImageKey: smallImageKey,    
+        smallImageText: smallImageText,
+        partySize: playerCount,
+        partyMax: maxPlayerCount,
+        partyId: partyId,
+        buttons: [{
+            label: "Play",
+            url: "https://www.beyondallreason.info/",
+        }],
+    });
+});
+
+rpc.login({ clientId }).catch(console.error);


### PR DESCRIPTION
This is the launcher side PR for adding Discord Rich Presence support for BAR.
Statuses won't be shown until both Chobby and launcher changes are merged and active, but they can be merged independently without new issues.
[Chobby PR](https://github.com/beyond-all-reason/BYAR-Chobby/pull/578)

# What is DIscord Rich Presence?
Discord Rich Presence makes it possible to display statuses and details of games and programs that support it.
If you use DIscord you probably saw people that have statuses below their names: "Playing *game*", "Listening to _Spotify song_", "Streaming" etc. Rich Presence makes this possible and currently, unless they added BAR in their registered games section in Discord settings, people playing BAR wouldn't have the "Playing Beyond All Reason" status.

Activity status will only be shown for people who enable it in Discord settings under Activity Settings>Activity Privacy>Activity Status section.

Rich Presence supports more than just showing a basic one liner. For now I added more details, but in the future it is possible to expand it with the ability to send game invites and join games directly from Discord.

# Example
![image](https://github.com/beyond-all-reason/spring-launcher/assets/44340857/079539ef-6e96-473b-88a2-137e3556670c)
![image](https://github.com/beyond-all-reason/spring-launcher/assets/44340857/1d71854d-c2b4-4f78-9c3a-255e286a4ca0)

# Details shown
- Game title
- Map name
- Map image, thanks to @p2004a
- Status: playing, spectating, in menu, in (running) lobby, watching replay, skirmish
- Time elapsed
- Play button that leads to https://www.beyondallreason.info/

# What this PR does
- Adds [Discord.js RPC Extension](https://github.com/discordjs/RPC)
- New extension that receives `DiscordSetActivity` message from Chobby and sets Discord activity details
- Adds `config.json` to [.gitignore](https://github.com/beyond-all-reason/spring-launcher/blob/master/.gitignore)