### PR TITLE
Change author field from gajop to BAR Team

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build-mac": "electron-builder -m",
     "build": "electron-builder -wl"
   },
-  "author": "gajop",
+  "author": "BAR Team",
   "license": "ISC",
   "build": {
     "appId": "com.springrts.launcher",


### PR DESCRIPTION
Because this field appears as "Copyright" in viewers.

Beyond-All-Reason-1.2838.0.exe: https://www.virustotal.com/gui/file/55cc664c9b8536524d7424a9a3eac6641d96a5a2540d948efbd4d079b1e3f9d9/details
![Screenshot_529](https://github.com/beyond-all-reason/spring-launcher/assets/124457076/4af96c08-99b3-4a5e-825c-922814e9263b)
