### PR TITLE
chore: add AI usage policy

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,69 @@
+# AI Usage Policy
+
+## Disclosure requirements
+
+**AI usage in generating code must be explicitly disclosed in the associated Pull Request.**
+Contributors must clearly state:
+- which AI tool(s) were used (for example: Claude Code, Cursor, Copilot)
+- the extent to which the contribution was AI-assisted
+
+**Undisclosed AI usage will result in closure.**
+If maintainers reasonably suspect undisclosed AI use, the pull request will be closed.
+
+**Non-direct AI usage does not require disclosure.**
+The above requirements apply to cases where AI is used to write production code.
+If AI is used solely as an advisory or educational tool, disclosure is not required.
+
+## Verification and testing
+
+**All AI-assisted code must be fully verified by a human contributor.**
+Contributors are responsible for ensuring that:
+- the code has been run and tested
+- the code behaves correctly in practice, not just in theory
+
+It is recommended to attach test artifacts, such as screenshots or recordings, that demonstrate your code working for each test step.
+
+## Issues and discussions
+
+**AI assistance is permitted in issues and discussions, with a strict human-in-the-loop requirement:**
+
+- AI-generated content must be reviewed and edited by a human before submission.
+- Verbosity, noise, and speculative content must be removed.
+- Contributors remain responsible for research, accuracy, and clarity.
+
+AI may assist with explanations, summaries, or drafting, but must not replace understanding or judgment.
+
+## Prohibited content
+
+**AI-generated media is not permitted.**
+This includes, but is not limited to: art, images, videos, and audio.
+Only text and code are eligible for AI assistance, subject to the rules above.
+
+## Enforcement
+
+**Repeated or intentional misuse of AI tools may result in contributor bans.**
+Maintainers may enforce this policy at their discretion.
+
+## Why is this important?
+
+This repository is maintained by humans.
+
+Every issue, discussion, and pull request is read and reviewed by maintainers who volunteer their time and expertise. Submitting low-effort, unverified, or poorly understood work shifts the burden of validation onto maintainers and is considered disrespectful of that effort.
+
+The primary behavior this policy seeks to prevent is **Vibe Coding**, defined as the uncritical generation and submission of AI-produced code without sufficient understanding, verification, or accountability by the contributor. This policy exists to prevent wasted maintainer time and to ensure high standards of code quality and maintainability.
+
+This policy exists to protect maintainers, preserve code quality, and ensure that collaboration remains productive and sustainable.
+
+## Responsible AI usage is welcome
+
+Maintainers actively use AI tools as part of their workflow.
+This policy does not represent an anti-AI position.
+
+The restrictions outlined above exist due to repeated misuse of AI by contributors who submit unverified, low-quality, or poorly understood work. The issue is not the tools themselves, but how they are applied.
+
+When used responsibly, transparently, and with proper human oversight, AI can be a valuable productivity aid.
+
+## Attribution
+
+This policy is adapted from the original AI usage policy published by the [Ghostty](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md) organization.
+The maintainers acknowledge and appreciate the clarity and intent of the original text.


### PR DESCRIPTION
Adds `AI_POLICY.md` to the repository and references it in existing `CONTRIBUTING.md` and PR template files.

See the policy for full details on disclosure requirements, verification expectations, and responsible use guidelines.