### PR TITLE
[Draft/Suggestion] Open .sdfz replays through the launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Electron-based SpringRTS Launcher app",
   "main": "src/main.js",
   "scripts": {
-    "test": "jest",
+    "test": "node --test",
     "lint": "eslint \"./src/**/*.js\"",
     "start": "electron .",
     "start-dev": "electron . --dev",
@@ -18,6 +18,15 @@
   "license": "ISC",
   "build": {
     "appId": "com.springrts.launcher",
+    "fileAssociations": [
+      {
+        "ext": "sdfz",
+        "name": "Spring Replay",
+        "description": "Spring replay file",
+        "role": "Viewer",
+        "mimeType": "application/x-spring-replay"
+      }
+    ],
     "extraFiles": [
       "files/*"
     ],

--- a/src/launcher_gui.js
+++ b/src/launcher_gui.js
@@ -135,7 +135,7 @@ app.prependListener('ready', () => {
 
 		if (config.no_downloads && config.auto_start) {
 			wizard.nextStep();
-		} else if (config.auto_download) {
+		} else if (config.auto_download && !wizard.started) {
 			gui.send('wizard-started');
 			wizard.nextStep();
 		} else {

--- a/src/launcher_wizard.js
+++ b/src/launcher_wizard.js
@@ -32,6 +32,7 @@ class Wizard extends EventEmitter {
 	constructor() {
 		super();
 		this.isActive = false;
+		this.startRequested = false;
 		this.generateSteps();
 	}
 
@@ -336,12 +337,13 @@ class Wizard extends EventEmitter {
 		log.info(`Step: ${JSON.stringify(step, null, 4)}`);
 
 		if (step.name === 'start') {
-			if (!(config.auto_start || forced)) {
+			if (!(config.auto_start || forced || this.startRequested)) {
 				gui.send('wizard-stopped');
 				gui.send('wizard-finished');
 				this.steps.push(step);
 				return false;
 			}
+			this.startRequested = false;
 		} else {
 			gui.send('wizard-next-step', {
 				name: step.name,
@@ -351,6 +353,13 @@ class Wizard extends EventEmitter {
 
 		step.action(step);
 		return true;
+	}
+
+	requestStart() {
+		this.startRequested = true;
+		if (!this.started || (this.steps[0] && this.steps[0].name === 'start')) {
+			this.nextStep(true);
+		}
 	}
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { app, ipcMain } = require('electron');
+const { app, dialog, ipcMain } = require('electron');
+const path = require('path');
 
 require('@electron/remote/main').initialize();
 
@@ -40,12 +41,95 @@ const { wizard } = require('./launcher_wizard');
 // Setup downloader bindings
 require('./launcher_downloader');
 const { generateAndBroadcastWizard } = require('./launcher_wizard_util');
-// TODO: Despite not using it in this file, we have to require spring_api here
-require('./spring_api');
+const { bridge } = require('./spring_api');
 const { launcher } = require('./engine_launcher');
 const { writePath } = require('./spring_platform');
 const log_uploader = require('./log_uploader');
 const file_opener = require('./file_opener');
+const { ReplayOpenHandler } = require('./replay_open_handler');
+const { ReplayFileAssociation } = require('./replay_file_association');
+
+const REPLAY_ASSOCIATION_SETTING = 'sdfzDefaultApplication';
+
+async function confirmReplayOverwrite(source, destination) {
+	const mainWindow = gui.getMainWindow();
+	const options = {
+		type: 'warning',
+		title: 'Replay already exists',
+		message: `A different replay named "${path.basename(destination)}" already exists.`,
+		detail: `Overwrite it with ${source}?`,
+		buttons: ['Cancel', 'Overwrite'],
+		defaultId: 0,
+		cancelId: 0,
+		noLink: true,
+	};
+	const result = mainWindow && mainWindow.isVisible()
+		? await dialog.showMessageBox(mainWindow, options)
+		: await dialog.showMessageBox(options);
+	return result.response === 1;
+}
+
+const replayOpenHandler = new ReplayOpenHandler(
+	bridge, writePath, log, confirmReplayOverwrite
+);
+const replayFileAssociation = new ReplayFileAssociation({ log });
+let replayAssociationUpdate = Promise.resolve();
+
+function getReplayAssociationEnabled() {
+	if (!settings.hasSync(REPLAY_ASSOCIATION_SETTING)) {
+		return true;
+	}
+	return settings.getSync(REPLAY_ASSOCIATION_SETTING) !== false;
+}
+
+function sendReplayAssociationState() {
+	gui.send('replay-file-association-state', getReplayAssociationEnabled());
+}
+
+async function syncReplayFileAssociation() {
+	if (!app.isPackaged || !['linux', 'win32'].includes(process.platform)) {
+		return;
+	}
+	const enabled = getReplayAssociationEnabled();
+	try {
+		const registered = await replayFileAssociation.isRegistered();
+		if (enabled && !registered) {
+			await replayFileAssociation.register();
+			log.info('Registered the launcher as a handler for .sdfz files');
+		} else if (!enabled) {
+			await replayFileAssociation.unregister();
+			if (registered) {
+				log.info('Unregistered the launcher as a handler for .sdfz files');
+			}
+		}
+	} catch (error) {
+		log.error(`Failed to update the .sdfz file association: ${error.stack || error}`);
+		gui.send('error', `Failed to update the .sdfz file association: ${error.message}`);
+	}
+}
+
+function queueReplayFileAssociationUpdate() {
+	replayAssociationUpdate = replayAssociationUpdate.then(syncReplayFileAssociation);
+	return replayAssociationUpdate;
+}
+
+async function openReplayArgs(argv, workingDirectory) {
+	try {
+		const replayCount = await replayOpenHandler.openArgs(argv, workingDirectory);
+		if (replayCount > 0 && launcher.state !== 'running') {
+			wizard.requestStart();
+		}
+	} catch (error) {
+		log.error(`Failed to import replay: ${error.stack || error}`);
+		gui.send('error', `Failed to import replay: ${error.message}`);
+	}
+}
+
+bridge.on('ReplayHandlerReady', () => replayOpenHandler.setChobbyReady());
+
+app.on('second-instance', (_event, argv, workingDirectory) => {
+	openReplayArgs(argv, workingDirectory);
+});
 
 launcher.on('stdout', (text) => {
 	log.info(text);
@@ -102,6 +186,35 @@ ipcMain.on('open-install-dir', () => {
 	}
 });
 
+ipcMain.on('open-replay', async () => {
+	const result = await dialog.showOpenDialog(gui.getMainWindow(), {
+		properties: ['openFile'],
+		filters: [
+			{ name: 'Spring replays', extensions: ['sdfz'] },
+			{ name: 'All files', extensions: ['*'] },
+		],
+	});
+	if (!result.canceled && result.filePaths.length > 0) {
+		openReplayArgs(result.filePaths, process.cwd());
+	}
+});
+
+ipcMain.on('open-replay-paths', (_event, replayPaths) => {
+	if (Array.isArray(replayPaths)) {
+		openReplayArgs(replayPaths, process.cwd());
+	}
+});
+
+ipcMain.on('set-replay-file-association', async (_event, enabled) => {
+	settings.setSync(REPLAY_ASSOCIATION_SETTING, Boolean(enabled));
+	await queueReplayFileAssociationUpdate();
+	sendReplayAssociationState();
+});
+
+ipcMain.on('get-replay-file-association', () => {
+	sendReplayAssociationState();
+});
+
 ipcMain.on('wizard-next', () => {
 	wizard.nextStep(true);
 });
@@ -132,6 +245,9 @@ app.on('ready', () => {
 			settings.unsetSync('config');
 		}
 	}
+	sendReplayAssociationState();
+	queueReplayFileAssociationUpdate();
+	openReplayArgs(process.argv, process.cwd());
 });
 
 app.on('window-all-closed', () => {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -27,6 +27,7 @@
           <button id="btn-show-log" class="button is-small status-button" tabindex="-1">Toggle log</button>
           <button id="btn-upload-log" class="button is-small status-button" tabindex="-1">Upload log</button>
           <button id="btn-show-dir" class="button is-small status-button" tabindex="-1">Open install directory</button>
+          <button id="btn-open-replay" class="button is-small status-button" tabindex="-1">Open replay</button>
         </div>
         <div class="progress-area">
           <progress id="progress-part" max="100" value="0" class="progress is-primary is-small">0%</progress>
@@ -35,7 +36,10 @@
         <div class="mainbtn">
           <button id="btn-progress" class="button is-primary is-large">Start</button>
         </div>
-        <label class="checkbox" id="lbl-check-for-updates"><input type="checkbox" id="cb-check-for-updates">Update</label>
+        <div class="preferences">
+          <label class="checkbox" id="lbl-check-for-updates"><input type="checkbox" id="cb-check-for-updates">Update</label>
+          <label class="checkbox" id="lbl-replay-file-association"><input type="checkbox" id="cb-replay-file-association" checked>Default .sdfz app</label>
+        </div>
         <div id="footerLinks"></div>
       </div>
       <div id="note-content" class="box infobox" tabindex="-1"></div>

--- a/src/renderer/renderer_misc.js
+++ b/src/renderer/renderer_misc.js
@@ -1,14 +1,43 @@
 'use strict';
 
-const { ipcRenderer } = require('electron');
+const { ipcRenderer, webUtils } = require('electron');
 const isDev = !require('@electron/remote').app.isPackaged;
 
 const btnShowDir = document.getElementById('btn-show-dir');
+const btnOpenReplay = document.getElementById('btn-open-replay');
+const cbReplayFileAssociation = document.getElementById('cb-replay-file-association');
 const lblMainTitle = document.getElementById('title');
 const footerLinks = document.getElementById('footerLinks');
 
 btnShowDir.addEventListener('click', () => {
 	ipcRenderer.send('open-install-dir');
+});
+
+btnOpenReplay.addEventListener('click', () => {
+	ipcRenderer.send('open-replay');
+});
+
+cbReplayFileAssociation.addEventListener('change', () => {
+	ipcRenderer.send('set-replay-file-association', cbReplayFileAssociation.checked);
+});
+
+ipcRenderer.on('replay-file-association-state', (_event, enabled) => {
+	cbReplayFileAssociation.checked = enabled;
+});
+ipcRenderer.send('get-replay-file-association');
+
+document.addEventListener('dragover', event => {
+	event.preventDefault();
+});
+
+document.addEventListener('drop', event => {
+	event.preventDefault();
+	const replayPaths = [...event.dataTransfer.files]
+		.map(file => webUtils.getPathForFile(file))
+		.filter(filePath => filePath.toLowerCase().endsWith('.sdfz'));
+	if (replayPaths.length > 0) {
+		ipcRenderer.send('open-replay-paths', replayPaths);
+	}
 });
 
 function updateLinks(links) {

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -47,13 +47,18 @@ body {
   grid-area: mainbtn;
 }
 
-#lbl-check-for-updates {
-  grid-area: checkupdates;
+.preferences {
+  grid-area: preferences;
   align-self: end;
   top: 4px;
+  display: flex;
+  flex-direction: column;
+  white-space: nowrap;
+  font-size: 12px;
 }
 
-#cb-check-for-updates {
+#cb-check-for-updates,
+#cb-replay-file-association {
   margin-right: 6px;
 }
 
@@ -90,7 +95,7 @@ body {
     'controls controls mainbtn'
     'status status mainbtn'
     'prog prog mainbtn'
-    'prog prog checkupdates'
+    'prog prog preferences'
     'links links links';
   grid-template-columns: 1fr 4fr 1fr;
   grid-template-rows: 50fr 1fr 1fr 1fr 1fr 1fr;

--- a/src/replay_file_association.js
+++ b/src/replay_file_association.js
@@ -1,0 +1,308 @@
+'use strict';
+
+const childProcess = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { promisify } = require('util');
+
+const execFile = promisify(childProcess.execFile);
+
+const EXTENSION = '.sdfz';
+const FILE_CLASS = 'Spring Replay';
+const MIME_TYPE = 'application/x-spring-replay';
+const LINUX_DESKTOP_FILE = 'spring-launcher-sdfz.desktop';
+const WINDOWS_APPLICATION_NAME = 'BAR Spring Launcher';
+
+function quoteDesktopValue(value) {
+	return `"${value.replace(/([\\"`$])/g, '\\$1').replace(/%/g, '%%')}"`;
+}
+
+function getHandlerPath(env = process.env, executablePath = process.execPath) {
+	return env.PORTABLE_EXECUTABLE_FILE || env.APPIMAGE || executablePath;
+}
+
+class ReplayFileAssociation {
+	constructor(options = {}) {
+		this.platform = options.platform || process.platform;
+		this.executablePath = options.executablePath || getHandlerPath();
+		this.homePath = options.homePath || os.homedir();
+		this.environment = options.environment || process.env;
+		this.execFile = options.execFile || execFile;
+		this.fs = options.fs || fs.promises;
+		this.log = options.log || console;
+	}
+
+	getExecutableName() {
+		return this.platform === 'win32'
+			? path.win32.basename(this.executablePath)
+			: path.basename(this.executablePath);
+	}
+
+	async isRegistered() {
+		if (this.platform === 'win32') {
+			return this.isRegisteredWindows();
+		}
+		if (this.platform === 'linux') {
+			return this.isRegisteredLinux();
+		}
+		return false;
+	}
+
+	async register() {
+		if (this.platform === 'win32') {
+			await this.registerWindows();
+		} else if (this.platform === 'linux') {
+			await this.registerLinux();
+		}
+	}
+
+	async unregister() {
+		if (this.platform === 'win32') {
+			await this.unregisterWindows();
+		} else if (this.platform === 'linux') {
+			await this.unregisterLinux();
+		}
+	}
+
+	async run(command, args, ignoreFailure = false) {
+		try {
+			return await this.execFile(command, args, { windowsHide: true });
+		} catch (error) {
+			if (ignoreFailure) {
+				return null;
+			}
+			throw error;
+		}
+	}
+
+	async queryWindowsValue(key, valueName) {
+		const args = ['query', key];
+		if (valueName === '') {
+			args.push('/ve');
+		} else {
+			args.push('/v', valueName);
+		}
+		const result = await this.run('reg.exe', args, true);
+		if (!result) {
+			return null;
+		}
+		const line = result.stdout.split(/\r?\n/).find(candidate => candidate.includes('REG_SZ'));
+		return line ? line.split(/\s+REG_SZ\s+/)[1] || '' : null;
+	}
+
+	async setWindowsValue(key, valueName, value, type = 'REG_SZ') {
+		const args = ['add', key];
+		if (valueName === '') {
+			args.push('/ve');
+		} else {
+			args.push('/v', valueName);
+		}
+		args.push('/t', type, '/d', value, '/f');
+		await this.run('reg.exe', args);
+	}
+
+	async deleteWindowsValue(key, valueName) {
+		const args = ['delete', key];
+		if (valueName === '') {
+			args.push('/ve');
+		} else {
+			args.push('/v', valueName);
+		}
+		args.push('/f');
+		await this.run('reg.exe', args, true);
+	}
+
+	async isRegisteredWindows() {
+		const classesKey = 'HKCU\\Software\\Classes';
+		const capabilitiesPath = `Software\\${WINDOWS_APPLICATION_NAME}\\Capabilities`;
+		const expectedCommand = `"${this.executablePath}" "%1"`;
+		const [registeredCapabilities, command] = await Promise.all([
+			this.queryWindowsValue('HKCU\\Software\\RegisteredApplications', WINDOWS_APPLICATION_NAME),
+			this.queryWindowsValue(`${classesKey}\\${FILE_CLASS}\\shell\\open\\command`, ''),
+		]);
+		return registeredCapabilities === capabilitiesPath && command === expectedCommand;
+	}
+
+	async registerWindows() {
+		const classesKey = 'HKCU\\Software\\Classes';
+		const extensionKey = `${classesKey}\\${EXTENSION}`;
+		const fileClassKey = `${classesKey}\\${FILE_CLASS}`;
+		const applicationKey = `${classesKey}\\Applications\\${this.getExecutableName()}`;
+		const capabilitiesPath = `Software\\${WINDOWS_APPLICATION_NAME}\\Capabilities`;
+		const capabilitiesKey = `HKCU\\${capabilitiesPath}`;
+
+		await this.setWindowsValue(`${extensionKey}\\OpenWithProgids`, FILE_CLASS, '', 'REG_NONE');
+		await this.setWindowsValue(fileClassKey, '', 'Spring replay file');
+		await this.setWindowsValue(`${fileClassKey}\\DefaultIcon`, '', `"${this.executablePath}",0`);
+		await this.setWindowsValue(`${fileClassKey}\\shell`, '', 'open');
+		await this.setWindowsValue(`${fileClassKey}\\shell\\open`, '', 'Open with BAR');
+		await this.setWindowsValue(
+			`${fileClassKey}\\shell\\open\\command`, '', `"${this.executablePath}" "%1"`
+		);
+		await this.setWindowsValue(
+			`${applicationKey}\\shell\\open\\command`, '', `"${this.executablePath}" "%1"`
+		);
+		await this.setWindowsValue(`${applicationKey}\\SupportedTypes`, EXTENSION, '', 'REG_NONE');
+		await this.setWindowsValue(capabilitiesKey, 'ApplicationName', WINDOWS_APPLICATION_NAME);
+		await this.setWindowsValue(
+			capabilitiesKey, 'ApplicationDescription', 'Open Spring replay files with BAR'
+		);
+		await this.setWindowsValue(`${capabilitiesKey}\\FileAssociations`, EXTENSION, FILE_CLASS);
+		await this.setWindowsValue(
+			'HKCU\\Software\\RegisteredApplications', WINDOWS_APPLICATION_NAME, capabilitiesPath
+		);
+	}
+
+	async unregisterWindows() {
+		const classesKey = 'HKCU\\Software\\Classes';
+		const extensionKey = `${classesKey}\\${EXTENSION}`;
+		const currentClass = await this.queryWindowsValue(extensionKey, '');
+		if (currentClass === FILE_CLASS) {
+			const backupName = `${FILE_CLASS}_backup`;
+			const backupClass = await this.queryWindowsValue(extensionKey, backupName);
+			if (backupClass) {
+				await this.setWindowsValue(extensionKey, '', backupClass);
+			} else {
+				await this.deleteWindowsValue(extensionKey, '');
+			}
+			await this.deleteWindowsValue(extensionKey, backupName);
+		}
+		await this.deleteWindowsValue(`${extensionKey}\\OpenWithProgids`, FILE_CLASS);
+		await this.run('reg.exe', ['delete', `${classesKey}\\${FILE_CLASS}`, '/f'], true);
+		await this.run(
+			'reg.exe',
+			['delete', `${classesKey}\\Applications\\${this.getExecutableName()}`, '/f'],
+			true
+		);
+		await this.deleteWindowsValue(
+			'HKCU\\Software\\RegisteredApplications', WINDOWS_APPLICATION_NAME
+		);
+		await this.run(
+			'reg.exe', ['delete', `HKCU\\Software\\${WINDOWS_APPLICATION_NAME}`, '/f'], true
+		);
+	}
+
+	getLinuxPaths() {
+		const configHome = this.environment.XDG_CONFIG_HOME || path.join(this.homePath, '.config');
+		const dataHome = this.environment.XDG_DATA_HOME || path.join(this.homePath, '.local', 'share');
+		return {
+			desktopDirectory: path.join(dataHome, 'applications'),
+			desktopPath: path.join(dataHome, 'applications', LINUX_DESKTOP_FILE),
+			mimeDirectory: path.join(dataHome, 'mime'),
+			mimePackageDirectory: path.join(dataHome, 'mime', 'packages'),
+			mimePackagePath: path.join(dataHome, 'mime', 'packages', 'spring-launcher-sdfz.xml'),
+			mimeAppsPaths: [
+				path.join(configHome, 'mimeapps.list'),
+				path.join(dataHome, 'applications', 'mimeapps.list'),
+				path.join(dataHome, 'applications', 'defaults.list'),
+			],
+		};
+	}
+
+	getLinuxDesktopEntry() {
+		return [
+			'[Desktop Entry]',
+			'Type=Application',
+			'Name=BAR Spring Launcher',
+			'Comment=Open Spring replay files with BAR',
+			`Exec=${quoteDesktopValue(this.executablePath)} %f`,
+			'Terminal=false',
+			'Categories=Game;',
+			`MimeType=${MIME_TYPE};`,
+			'',
+		].join('\n');
+	}
+
+	getLinuxMimePackage() {
+		return [
+			'<?xml version="1.0" encoding="UTF-8"?>',
+			'<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">',
+			`  <mime-type type="${MIME_TYPE}">`,
+			'    <comment>Spring replay file</comment>',
+			'    <glob pattern="*.sdfz"/>',
+			'  </mime-type>',
+			'</mime-info>',
+			'',
+		].join('\n');
+	}
+
+	async isRegisteredLinux() {
+		const { desktopPath } = this.getLinuxPaths();
+		let desktopEntry;
+		try {
+			desktopEntry = await this.fs.readFile(desktopPath, 'utf8');
+		} catch (error) {
+			if (error.code === 'ENOENT') {
+				return false;
+			}
+			throw error;
+		}
+		if (desktopEntry !== this.getLinuxDesktopEntry()) {
+			return false;
+		}
+		const result = await this.run('xdg-mime', ['query', 'default', MIME_TYPE], true);
+		return result && result.stdout.trim() === LINUX_DESKTOP_FILE;
+	}
+
+	async registerLinux() {
+		const paths = this.getLinuxPaths();
+		await Promise.all([
+			this.fs.mkdir(paths.desktopDirectory, { recursive: true }),
+			this.fs.mkdir(paths.mimePackageDirectory, { recursive: true }),
+		]);
+		await Promise.all([
+			this.fs.writeFile(paths.desktopPath, this.getLinuxDesktopEntry()),
+			this.fs.writeFile(paths.mimePackagePath, this.getLinuxMimePackage()),
+		]);
+		await this.run('update-mime-database', [paths.mimeDirectory], true);
+		await this.run('update-desktop-database', [paths.desktopDirectory], true);
+		await this.run('xdg-mime', ['default', LINUX_DESKTOP_FILE, MIME_TYPE]);
+	}
+
+	async unregisterLinux() {
+		const paths = this.getLinuxPaths();
+		await Promise.all(paths.mimeAppsPaths.map(filePath => this.removeLinuxMimeAssociation(filePath)));
+		await Promise.all([
+			this.fs.rm(paths.desktopPath, { force: true }),
+			this.fs.rm(paths.mimePackagePath, { force: true }),
+		]);
+		await this.run('update-mime-database', [paths.mimeDirectory], true);
+		await this.run('update-desktop-database', [paths.desktopDirectory], true);
+	}
+
+	async removeLinuxMimeAssociation(filePath) {
+		let contents;
+		try {
+			contents = await this.fs.readFile(filePath, 'utf8');
+		} catch (error) {
+			if (error.code === 'ENOENT') {
+				return;
+			}
+			throw error;
+		}
+
+		const prefix = `${MIME_TYPE}=`;
+		const updatedLines = contents.split('\n').flatMap(line => {
+			if (!line.startsWith(prefix)) {
+				return [line];
+			}
+			const handlers = line.slice(prefix.length)
+				.split(';')
+				.filter(handler => handler && handler !== LINUX_DESKTOP_FILE);
+			return handlers.length > 0 ? [`${prefix}${handlers.join(';')};`] : [];
+		});
+		const updatedContents = updatedLines.join('\n');
+		if (updatedContents !== contents) {
+			await this.fs.writeFile(filePath, updatedContents);
+		}
+	}
+}
+
+module.exports = {
+	FILE_CLASS,
+	LINUX_DESKTOP_FILE,
+	MIME_TYPE,
+	ReplayFileAssociation,
+	getHandlerPath,
+};

--- a/src/replay_file_association.test.js
+++ b/src/replay_file_association.test.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('path');
+const { describe, test } = require('node:test');
+
+const {
+	LINUX_DESKTOP_FILE,
+	MIME_TYPE,
+	ReplayFileAssociation,
+	getHandlerPath,
+} = require('./replay_file_association');
+
+describe('ReplayFileAssociation', () => {
+	test('uses the stable portable or AppImage path when available', () => {
+		assert.equal(getHandlerPath({ PORTABLE_EXECUTABLE_FILE: 'C:\\BAR.exe' }, '/tmp/electron'), 'C:\\BAR.exe');
+		assert.equal(getHandlerPath({ APPIMAGE: '/games/BAR.AppImage' }, '/tmp/electron'), '/games/BAR.AppImage');
+		assert.equal(getHandlerPath({}, '/opt/BAR/spring-launcher'), '/opt/BAR/spring-launcher');
+	});
+
+	test('registers a Linux desktop handler and makes it the MIME default', async () => {
+		const writes = new Map();
+		const calls = [];
+		const association = new ReplayFileAssociation({
+			platform: 'linux',
+			executablePath: '/games/BAR.AppImage',
+			homePath: '/home/test',
+			fs: {
+				mkdir: async () => {},
+				writeFile: async (filePath, contents) => writes.set(filePath, contents),
+				rm: async () => {},
+			},
+			execFile: async (command, args) => {
+				calls.push([command, args]);
+				return { stdout: '' };
+			},
+		});
+
+		await association.register();
+
+		const desktopPath = path.join('/home/test/.local/share/applications', LINUX_DESKTOP_FILE);
+		assert.match(writes.get(desktopPath), /Exec="\/games\/BAR\.AppImage" %f/);
+		assert.deepEqual(calls.at(-1), [
+			'xdg-mime', ['default', LINUX_DESKTOP_FILE, MIME_TYPE],
+		]);
+	});
+
+	test('recognizes only the current Linux executable as the default handler', async () => {
+		let desktopEntry;
+		const association = new ReplayFileAssociation({
+			platform: 'linux',
+			executablePath: '/games/BAR.AppImage',
+			homePath: '/home/test',
+			fs: {
+				readFile: async () => desktopEntry,
+			},
+			execFile: async () => ({ stdout: `${LINUX_DESKTOP_FILE}\n` }),
+		});
+		desktopEntry = association.getLinuxDesktopEntry();
+		assert.equal(await association.isRegistered(), true);
+		desktopEntry = desktopEntry.replace('/games/BAR.AppImage', '/old/BAR.AppImage');
+		assert.equal(await association.isRegistered(), false);
+	});
+
+	test('writes the Windows Open With and Default Apps registrations', async () => {
+		const calls = [];
+		const association = new ReplayFileAssociation({
+			platform: 'win32',
+			executablePath: 'C:\\Games\\BAR\\spring-launcher.exe',
+			execFile: async (command, args) => {
+				calls.push([command, args]);
+				if (args[0] === 'query') {
+					const error = new Error('not found');
+					throw error;
+				}
+				return { stdout: '' };
+			},
+		});
+
+		await association.register();
+
+		assert.ok(calls.some(([, args]) =>
+			args.includes('HKCU\\Software\\Classes\\Applications\\spring-launcher.exe\\SupportedTypes') &&
+			args.includes('.sdfz')
+		));
+		assert.ok(calls.some(([, args]) =>
+			args.includes('HKCU\\Software\\RegisteredApplications') &&
+			args.includes('BAR Spring Launcher') &&
+			args.includes('Software\\BAR Spring Launcher\\Capabilities')
+		));
+		assert.ok(calls.some(([, args]) =>
+			args.includes('"C:\\Games\\BAR\\spring-launcher.exe" "%1"')
+		));
+	});
+
+	test('removes the Linux handler files when disabled', async () => {
+		const removed = [];
+		const writes = new Map();
+		const association = new ReplayFileAssociation({
+			platform: 'linux',
+			executablePath: '/games/BAR.AppImage',
+			homePath: '/home/test',
+			fs: {
+				rm: async filePath => removed.push(filePath),
+				readFile: async filePath => {
+					if (filePath === '/home/test/.config/mimeapps.list') {
+						return `[Default Applications]\n${MIME_TYPE}=${LINUX_DESKTOP_FILE};other.desktop;\n`;
+					}
+					const error = new Error('not found');
+					error.code = 'ENOENT';
+					throw error;
+				},
+				writeFile: async (filePath, contents) => writes.set(filePath, contents),
+			},
+			execFile: async () => ({ stdout: '' }),
+		});
+
+		await association.unregister();
+
+		assert.ok(removed.includes('/home/test/.local/share/applications/spring-launcher-sdfz.desktop'));
+		assert.ok(removed.includes('/home/test/.local/share/mime/packages/spring-launcher-sdfz.xml'));
+		assert.equal(
+			writes.get('/home/test/.config/mimeapps.list'),
+			`[Default Applications]\n${MIME_TYPE}=other.desktop;\n`
+		);
+	});
+});

--- a/src/replay_open_handler.js
+++ b/src/replay_open_handler.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+function hashFile(filePath) {
+	return new Promise((resolve, reject) => {
+		const hash = crypto.createHash('sha256');
+		const stream = fs.createReadStream(filePath);
+		stream.on('error', reject);
+		hash.on('error', reject);
+		hash.on('finish', () => resolve(hash.digest('hex')));
+		stream.pipe(hash);
+	});
+}
+
+async function filesAreEqual(firstPath, secondPath) {
+	const [firstStat, secondStat] = await Promise.all([
+		fs.promises.stat(firstPath),
+		fs.promises.stat(secondPath),
+	]);
+	if (firstStat.size !== secondStat.size) {
+		return false;
+	}
+	const [firstHash, secondHash] = await Promise.all([
+		hashFile(firstPath),
+		hashFile(secondPath),
+	]);
+	return firstHash === secondHash;
+}
+
+class ReplayOpenHandler {
+	constructor(bridge, writePath, log, confirmOverwrite) {
+		this.bridge = bridge;
+		this.writePath = writePath;
+		this.log = log;
+		this.confirmOverwrite = confirmOverwrite;
+		this.pendingReplays = [];
+		this.chobbyReady = false;
+	}
+
+	getReplayFiles(argv, workingDirectory) {
+		return argv
+			.filter(arg => typeof arg === 'string' && arg.toLowerCase().endsWith('.sdfz'))
+			.map(arg => path.resolve(workingDirectory, arg));
+	}
+
+	async openArgs(argv, workingDirectory) {
+		const replayFiles = this.getReplayFiles(argv, workingDirectory);
+		let openedCount = 0;
+		for (const replayFile of replayFiles) {
+			if (await this.openFile(replayFile)) {
+				openedCount++;
+			}
+		}
+		return openedCount;
+	}
+
+	async openFile(sourcePath) {
+		const source = path.resolve(sourcePath);
+		const stat = await fs.promises.stat(source);
+		if (!stat.isFile()) {
+			throw new Error(`Replay path is not a file: ${source}`);
+		}
+
+		const demosPath = path.join(this.writePath, 'demos');
+		const destination = path.join(demosPath, path.basename(source));
+		await fs.promises.mkdir(demosPath, { recursive: true });
+
+		if (source !== path.resolve(destination)) {
+			let shouldCopy = true;
+			try {
+				if (await filesAreEqual(source, destination)) {
+					shouldCopy = false;
+					this.log.info(`Replay already imported with identical contents: ${destination}`);
+				} else {
+					if (!await this.confirmOverwrite(source, destination)) {
+						return null;
+					}
+				}
+			} catch (error) {
+				if (error.code !== 'ENOENT') {
+					throw error;
+				}
+			}
+
+			if (shouldCopy) {
+				await fs.promises.copyFile(source, destination);
+				await fs.promises.rm(`${destination}.cache`, { force: true });
+				this.log.info(`Imported replay: ${source} -> ${destination}`);
+			}
+		}
+
+		const relativePath = path.posix.join('demos', path.basename(destination));
+		this.queueReplay(relativePath);
+		return relativePath;
+	}
+
+	queueReplay(relativePath) {
+		if (this.chobbyReady) {
+			this.bridge.send('OpenReplay', { relativePath });
+			return;
+		}
+		this.pendingReplays.push(relativePath);
+	}
+
+	setChobbyReady() {
+		this.chobbyReady = true;
+		for (const relativePath of this.pendingReplays) {
+			this.bridge.send('OpenReplay', { relativePath });
+		}
+		this.pendingReplays = [];
+	}
+}
+
+module.exports = {
+	ReplayOpenHandler,
+	filesAreEqual,
+};

--- a/src/replay_open_handler.test.js
+++ b/src/replay_open_handler.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { afterEach, beforeEach, describe, test } = require('node:test');
+
+const { ReplayOpenHandler } = require('./replay_open_handler');
+
+describe('ReplayOpenHandler', () => {
+	let tempPath;
+	let writePath;
+	let bridgeCalls;
+	let overwriteCalls;
+	let overwriteResponse;
+	let handler;
+
+	beforeEach(async () => {
+		tempPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'spring-launcher-replay-'));
+		writePath = path.join(tempPath, 'data');
+		bridgeCalls = [];
+		overwriteCalls = [];
+		overwriteResponse = false;
+		handler = new ReplayOpenHandler(
+			{ send: (...args) => bridgeCalls.push(args) },
+			writePath,
+			{ info: () => {} },
+			async (...args) => {
+				overwriteCalls.push(args);
+				return overwriteResponse;
+			}
+		);
+	});
+
+	afterEach(async () => {
+		await fs.promises.rm(tempPath, { recursive: true, force: true });
+	});
+
+	test('reuses identical contents without copying or deleting the cache', async () => {
+		const source = path.join(tempPath, '2026-08-11_test.sdfz');
+		const destination = path.join(writePath, 'demos', path.basename(source));
+		await fs.promises.mkdir(path.dirname(destination), { recursive: true });
+		await fs.promises.writeFile(source, 'same replay');
+		await fs.promises.writeFile(destination, 'same replay');
+		await fs.promises.writeFile(`${destination}.cache`, 'valid cache');
+
+		assert.equal(await handler.openFile(source), 'demos/2026-08-11_test.sdfz');
+		assert.deepEqual(overwriteCalls, []);
+		assert.equal(await fs.promises.readFile(`${destination}.cache`, 'utf8'), 'valid cache');
+	});
+
+	test('asks before overwriting different contents and removes the stale cache', async () => {
+		const source = path.join(tempPath, '2026-08-11_test.sdfz');
+		const destination = path.join(writePath, 'demos', path.basename(source));
+		await fs.promises.mkdir(path.dirname(destination), { recursive: true });
+		await fs.promises.writeFile(source, 'new replay');
+		await fs.promises.writeFile(destination, 'old replay');
+		await fs.promises.writeFile(`${destination}.cache`, 'stale cache');
+		overwriteResponse = true;
+
+		assert.equal(await handler.openFile(source), 'demos/2026-08-11_test.sdfz');
+		assert.deepEqual(overwriteCalls, [[source, destination]]);
+		assert.equal(await fs.promises.readFile(destination, 'utf8'), 'new replay');
+		await assert.rejects(fs.promises.stat(`${destination}.cache`), { code: 'ENOENT' });
+	});
+
+	test('leaves a different existing replay untouched when overwrite is canceled', async () => {
+		const source = path.join(tempPath, '2026-08-11_test.sdfz');
+		const destination = path.join(writePath, 'demos', path.basename(source));
+		await fs.promises.mkdir(path.dirname(destination), { recursive: true });
+		await fs.promises.writeFile(source, 'new replay');
+		await fs.promises.writeFile(destination, 'old replay');
+
+		assert.equal(await handler.openFile(source), null);
+		assert.equal(await fs.promises.readFile(destination, 'utf8'), 'old replay');
+		assert.deepEqual(bridgeCalls, []);
+	});
+
+	test('queues the replay until Chobby reports that its handler is ready', async () => {
+		const source = path.join(tempPath, '2026-08-11_test.sdfz');
+		await fs.promises.writeFile(source, 'replay');
+
+		await handler.openFile(source);
+		assert.deepEqual(bridgeCalls, []);
+
+		handler.setChobbyReady();
+		assert.deepEqual(bridgeCalls, [[
+			'OpenReplay',
+			{ relativePath: 'demos/2026-08-11_test.sdfz' },
+		]]);
+	});
+
+	test('extracts sdfz paths case-insensitively from launcher arguments', () => {
+		assert.deepEqual(
+			handler.getReplayFiles(['launcher', 'one.SDFZ', '--dev', 'two.txt'], '/downloads'),
+			[path.resolve('/downloads/one.SDFZ')]
+		);
+	});
+});


### PR DESCRIPTION
## Status

> **Draft / suggestion / base for discussion.** This is intentionally proposed as a temporary compatibility improvement for the legacy launcher/Chobby path, not as a competing direction for the new client.

The new client is expected to provide this workflow. In the meantime, this implementation may already help some users who want to open downloaded `.sdfz` files with BAR without manually copying them into the replay directory and then scrolling the Replay list until they find it (or edit the date into the future). Maintainer feedback on whether carrying this temporary solution is worthwhile is very welcome.

## What this suggests

- accept `.sdfz` files from the file picker, drag and drop, initial process arguments, and Electron's `second-instance` event;
- import external replays into BAR's `demos/` directory;
- reuse identical files, confirm before overwriting a same-named replay with different contents, and invalidate stale parser caches after replacement;
- update/start BAR as usual, queue the replay request until Chobby is ready, then ask Chobby to open and focus it;
- offer an enabled-by-default, persistent `.sdfz` handler checkbox;
- register an XDG MIME/default handler on Linux and an Open With/Default Apps candidate on Windows. Modern Windows still leaves the final default-app choice to the user.

Opening the replay screen does **not** start replay playback automatically.

Paired Chobby PR: https://github.com/beyond-all-reason/BYAR-Chobby/pull/1241

## Verification

- `npm test` — 10 tests pass.
- `npm run lint` — passes.
- `npm run pack` and `npm run build-linux` — pass.
- Manually verified end to end on Linux using a packaged AppImage and the linked local Chobby **Dev Lobby**: dragging an external `.sdfz` imported it, started BAR, opened the Replays screen, and focused the imported replay.

## AI usage disclosure

OpenAI Codex was used interactively to trace the launcher/Chobby bridge, assist with implementation, tests, debugging, and drafting this PR text. I reviewed the changes and manually verified the end-to-end behavior described above.
